### PR TITLE
Adding leader and term workload

### DIFF
--- a/java/org/jgroups/raft/client/SyncClient.java
+++ b/java/org/jgroups/raft/client/SyncClient.java
@@ -23,7 +23,7 @@ import java.util.concurrent.locks.LockSupport;
 
 public class SyncClient<T> implements Receiver, AutoCloseable {
   protected final Log log = LogFactory.getLog(getClass());
-  private final String name;
+  protected final String name;
   private final Map<UUID, CompletableFuture<T>> requests = new ConcurrentHashMap<>();
 
   private long timeout;

--- a/java/org/jgroups/raft/client/SyncLeaderInspectionClient.java
+++ b/java/org/jgroups/raft/client/SyncLeaderInspectionClient.java
@@ -1,0 +1,33 @@
+package org.jgroups.raft.client;
+
+
+import clojure.lang.IPersistentVector;
+import clojure.lang.Tuple;
+import org.jgroups.raft.data.Request;
+import org.jgroups.raft.server.LeaderElection;
+import org.jgroups.util.ByteArrayDataOutputStream;
+import org.jgroups.util.UUID;
+import org.jgroups.util.Util;
+
+/**
+ * @author José Bolina
+ */
+public class SyncLeaderInspectionClient extends SyncClient<LeaderElection.ElectionInspection> {
+
+  public SyncLeaderInspectionClient(String name) {
+    super(name);
+  }
+
+  public IPersistentVector inspect() throws Throwable {
+    UUID uuid = prepareRequest();
+    ByteArrayDataOutputStream out = new ByteArrayDataOutputStream();
+    Util.objectToStream(new Request(uuid, ""), out);
+    LeaderElection.ElectionInspection ei = operation(uuid, out);
+    return Tuple.create(ei.leader(), ei.term());
+  }
+
+  @Override
+  public String toString() {
+    return "Client to -> " + name;
+  }
+}

--- a/java/org/jgroups/raft/server/LeaderElection.java
+++ b/java/org/jgroups/raft/server/LeaderElection.java
@@ -1,0 +1,98 @@
+package org.jgroups.raft.server;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.jgroups.Address;
+import org.jgroups.JChannel;
+import org.jgroups.logging.Log;
+import org.jgroups.logging.LogFactory;
+import org.jgroups.raft.RaftHandle;
+import org.jgroups.raft.data.Request;
+import org.jgroups.raft.data.Response;
+import org.jgroups.util.SizeStreamable;
+import org.jgroups.util.Util;
+
+/**
+ * Retrieve the leader and term. This does not receive the command through RAFT. It does something similar as
+ * if it were observed externally by a client or a user implementation retrieving the information.
+ *
+ * @author José Bolina
+ */
+public class LeaderElection implements TestStateMachine {
+  private static final Log log = LogFactory.getLog(LeaderElection.class);
+
+  protected final RaftHandle raft;
+  protected final JChannel ch;
+
+  public LeaderElection(JChannel ch) {
+    this.ch = ch;
+    this.raft = new RaftHandle(ch, this);
+  }
+
+  @Override
+  public Response receive(DataInput in) throws Exception {
+    log.info("Inspecting leader!!");
+    Address address = raft.leader();
+    long term = raft.currentTerm();
+    ElectionInspection ie = new ElectionInspection(address == null ? null : address.toString(), term);
+    log.info("Inspection result: %s", ie);
+
+    Request request = Util.objectFromStream(in);
+    return new Response(request.getUuid(), ie);
+  }
+
+  @Override
+  public byte[] apply(byte[] bytes, int i, int i1, boolean b) throws Exception {
+    return null;
+  }
+
+  @Override
+  public void readContentFrom(DataInput dataInput) throws Exception { }
+
+  @Override
+  public void writeContentTo(DataOutput dataOutput) throws Exception { }
+
+  public static class ElectionInspection implements SizeStreamable {
+    private String leader;
+    private long term;
+
+    public ElectionInspection() { }
+
+    public ElectionInspection(String leader, long term) {
+      this.leader = leader;
+      this.term = term;
+    }
+
+    public String leader() {
+      return leader;
+    }
+
+    public long term() {
+      return term;
+    }
+
+    @Override
+    public int serializedSize() {
+      return Util.size(leader) + Long.BYTES;
+    }
+
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
+      Util.writeString(leader, out);
+      out.writeLong(term);
+    }
+
+    @Override
+    public void readFrom(DataInput in) throws IOException {
+      this.leader = Util.readString(in);
+      this.term = in.readLong();
+    }
+
+    @Override
+    public String toString() {
+      return "[" + leader + ", " + term + "]";
+    }
+  }
+}

--- a/java/org/jgroups/raft/server/Server.java
+++ b/java/org/jgroups/raft/server/Server.java
@@ -118,6 +118,13 @@ public class Server implements Receiver, AutoCloseable, RAFT.RoleChange {
     return this;
   }
 
+  public Server prepareElectionInspection() throws Exception {
+    if (channel != null) throw new IllegalStateException("Channel is already running");
+    channel = new JChannel(props).name(name);
+    stateMachine = new LeaderElection(channel);
+    return this;
+  }
+
   public Server start(InetAddress bind, int port) throws Exception {
     Objects.requireNonNull(channel, "Channel is null");
     Objects.requireNonNull(stateMachine, "State machine is null");

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,6 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [dom-top "1.0.8"]
                  [jepsen "0.3.3"]
-                 [org.jgroups/jgroups "5.2.17.Final"]
+                 [org.jgroups/jgroups "5.2.18.Final"]
                  [org.jgroups/jgroups-raft "1.0.12.Final-SNAPSHOT"]]
   :repl-options {:init-ns jepsen.jgroups.raft})

--- a/server/project.clj
+++ b/server/project.clj
@@ -5,7 +5,7 @@
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [jepsen "0.3.3"]
-                 [org.jgroups/jgroups "5.2.17.Final"]
+                 [org.jgroups/jgroups "5.2.18.Final"]
                  [org.jgroups/jgroups-raft "1.0.12.Final-SNAPSHOT"]]
   :repl-options {:init-ns jgroups.raft.server}
   :aot [jgroups.raft.server]

--- a/server/src/jgroups/raft/server.clj
+++ b/server/src/jgroups/raft/server.clj
@@ -37,7 +37,8 @@
             (.withTimeout (long 30000)))]
     (case (:state-machine options)
       :register (.prepareReplicatedMapStateMachine s)
-      :counter  (.prepareCounterStateMachine s))
+      :counter  (.prepareCounterStateMachine s)
+      :election (.prepareElectionInspection s))
     (try+
       (.start s (InetAddress/getByName name) 9000)
       (catch Throwable t

--- a/src/jepsen/jgroups/server.clj
+++ b/src/jepsen/jgroups/server.clj
@@ -104,6 +104,7 @@
   [opts]
   (case (:workload opts)
     :counter #"counter"
+    :election #"election"
     #"register"))
 
 (defn stop!

--- a/src/jepsen/jgroups/workload/leader.clj
+++ b/src/jepsen/jgroups/workload/leader.clj
@@ -1,0 +1,86 @@
+(ns jepsen.jgroups.workload.leader
+  (:require
+    [clojure.tools.logging :refer :all]
+    [jepsen.checker :as checker]
+    [jepsen.checker.timeline :as timeline]
+    [jepsen.generator :as gen]
+    [jepsen.jgroups.workload.client :as c]
+    [knossos.model :as model])
+  (:import
+    (java.net InetAddress)
+    (knossos.model Model)
+    (org.jgroups.raft.client SyncLeaderInspectionClient)))
+
+(defn inspect
+  "An inspection operation that return the current leader and term."
+  [_ _]
+  {:type :invoke, :f :inspect, :value [nil 0]})
+
+(defn leader-inspect
+  "Inspect who the client thinks is the current leader and term."
+  [conn]
+  (.inspect conn))
+
+(defrecord LeaderInspectionClient [conn]
+  jepsen.client/Client
+
+  (open! [this test node]
+    (info "Starting leader inspection connected to" node)
+    (let [c (doto (SyncLeaderInspectionClient. node)
+              (.withTimeout (long (* 1000 (:operation-timeout test))))
+              (.withTargetAddress (InetAddress/getByName node))
+              (.withTargetPort 9000))]
+      (.start c)
+      (assoc this :conn c)))
+
+  (setup! [this test])
+
+  (invoke! [this test op]
+    (c/with-errors op #{:inspect}
+                   (assoc op :type :ok, :value (leader-inspect conn))))
+
+  (teardown! [this test])
+
+  (close! [_ test]
+    (.close conn)))
+
+(defn highest-term
+  "Returns the highest term in the given state."
+  [state]
+  (->> (keys state)
+       (reduce max)))
+
+(defn serialize-leader
+  "Serialize the leader name."
+  [addr]
+  (if (nil? addr) "null" addr))
+
+;; Create the model to verify leader and terms.
+;; The model verifies that one term has only one leader. If there are different leaders mapping to the same term,
+;; an inconsistent error is raised.
+;; Observe that this not verifies for majority or anything like that. It could be improved to keep track of the
+;; node who replied and assert that a majority of members sees the same leader.
+(defrecord LeaderModel [state]
+  Model
+
+  (step [r op]
+    (condp = (:f op)
+      :inspect (let [[inspected t _] (:value op)
+                     l (serialize-leader inspected)]
+                 (cond
+                   (empty? state) (LeaderModel. {t l})
+                   (contains? state t) (if (= (state t) l)
+                                         r
+                                         (model/inconsistent (str "leader at " t " was " (state t) " but received " l)))
+                   :else (LeaderModel. (assoc state t l)))))))
+
+(defn workload
+  "A workload to verify the leader election correctness."
+  [opts]
+  {:client    (LeaderInspectionClient. nil)
+   :checker   (checker/compose
+                {:timeline (timeline/html)
+                 :linear   (checker/linearizable
+                             {:model     (LeaderModel. {})
+                              :algorithm :linear})})
+   :generator (->> (gen/mix [inspect]))})

--- a/src/jepsen/jgroups/workload/workload.clj
+++ b/src/jepsen/jgroups/workload/workload.clj
@@ -1,13 +1,15 @@
 (ns jepsen.jgroups.workload.workload
   (:require
     [jepsen.jgroups.workload.register :as register]
-    [jepsen.jgroups.workload.counter :as counter]))
+    [jepsen.jgroups.workload.counter :as counter]
+    [jepsen.jgroups.workload.leader :as leader]))
 
 (def all-workloads
-  #{:single-register :multi-register :counter})
+  #{:single-register :multi-register :counter :election})
 
 (def workloads
   "A map of workloads to the corresponding constructor."
   {:single-register (partial register/workload (range 1))
    :multi-register  (partial register/workload (range))
-   :counter         counter/workload})
+   :counter         counter/workload
+   :election        leader/workload})


### PR DESCRIPTION
* Added a workload to verify that the client never observes different leaders for the same term.
* The server receives the request and returns its current leader and term available on RaftHandle. The message does not go through RAFT.